### PR TITLE
fix: 🐛 update customfield landing to json stringify

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -282,9 +282,8 @@ function genDealId() {
 
 function appendUserAgent(PXID) {
   const l = window.location;
-  const px =
-    PXID + "|" + window.navigator.userAgent + "|" + l.protocol + "//" + l.host + l.pathname;
-  return px;
+  const customfieldLanding = {px: PXID, agent: window.navigator.userAgent, landing: l.protocol + '//' + l.host + l.pathname};
+  return JSON.stringify(customfieldLanding);
 }
 
 function clearDataLocalStorage(fields) {


### PR DESCRIPTION
ปัจจุบันค่าจาก landing page ใช้การรวม string แล้ว  split "|" ทำให้ค่าเชคยากเมื่อนำไปใช้ว่าถูกต้องหรือไม่ เลยปรับเป็น json stringify ให้ถัดจากนี้ค่า properties เจาะจงมากขึ้นและใช้กับ การ handle event เก่าและใหม่ ใน feature update linkpay fb event meta track ที่จะเอาขึ้นได้ค่ะ